### PR TITLE
Generic surface extraction

### DIFF
--- a/src/algo/split.rs
+++ b/src/algo/split.rs
@@ -566,6 +566,10 @@ impl<T: Real> Mesh<T> {
                     };
                     TypedMesh::Tet(tetmesh)
                 }
+                CellType::Pyramid => {todo!()}
+                CellType::Hexahedron => {todo!()}
+                CellType::Wedge => {todo!()}
+                CellType::Quad => {todo!()}
             });
 
             // Clear new_vertex_index array.

--- a/src/io.rs
+++ b/src/io.rs
@@ -9,7 +9,7 @@
 //!  - `obj` via [`obj`](https://crates.io/obj).
 //!  - `vtk` via [`vtkio`](https://crates.io/vtkio).
 use std::path::Path;
-
+use vtkio::model;
 pub use vtkio::Vtk;
 
 use crate::attrib;
@@ -408,6 +408,7 @@ pub enum Error {
     UnsupportedDataFormat,
     MeshTypeMismatch,
     MissingMeshData,
+    UnsupportedCellTypes(Vec<model::CellType>),
 }
 
 impl std::error::Error for Error {
@@ -433,6 +434,9 @@ impl std::fmt::Display for Error {
             Error::UnsupportedDataFormat => write!(f, "Unsupported data format specified"),
             Error::MeshTypeMismatch => write!(f, "Mesh type doesn't match expected type"),
             Error::MissingMeshData => write!(f, "Missing mesh data"),
+            Error::UnsupportedCellTypes(t) => {
+                write!(f, "Cell types: {:#?}, are not supported!", t)
+            }
         }
     }
 }

--- a/src/io/vtk.rs
+++ b/src/io/vtk.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use crate::algo::merge::Merge;
 use crate::attrib::{Attrib, AttribDict, AttribIndex, Attribute, AttributeValue};
 use crate::mesh::topology::*;
@@ -7,6 +6,7 @@ use flatk::{
     consts::{U10, U11, U12, U13, U14, U15, U16, U2, U3, U4, U5, U6, U7, U8, U9},
     U,
 };
+use std::collections::HashSet;
 
 use super::MeshExtractor;
 use super::Real;
@@ -335,6 +335,9 @@ impl<T: Real> MeshExtractor<T> for model::Vtk {
                         let cell_type = match types[c] {
                             model::CellType::Triangle if n == 3 => CellType::Triangle,
                             model::CellType::Tetra if n == 4 => CellType::Tetrahedron,
+                            model::CellType::Pyramid if n == 5 => CellType::Pyramid,
+                            model::CellType::Hexahedron if n == 8 => CellType::Hexahedron,
+                            model::CellType::Wedge if n == 6 => CellType::Wedge,
                             _ => {
                                 // Not a valid cell type, skip it.
                                 begin = end as usize;
@@ -359,7 +362,10 @@ impl<T: Real> MeshExtractor<T> for model::Vtk {
                         }
                         begin = end as usize;
                     }
-                    println!("Cell variants: {:?}", cell_type_list.iter().collect::<Vec<_>>());
+                    println!(
+                        "Cell variants: {:?}",
+                        cell_type_list.iter().collect::<Vec<_>>()
+                    );
                     let mut mesh =
                         Mesh::from_cells_counts_and_types(pts, indices, counts, cell_types);
 

--- a/src/mesh/tetmesh.rs
+++ b/src/mesh/tetmesh.rs
@@ -9,7 +9,6 @@ mod extended;
 mod surface;
 
 pub use extended::*;
-pub use surface::*;
 
 use crate::attrib::*;
 use crate::mesh::topology::*;

--- a/src/mesh/tetmesh/surface.rs
+++ b/src/mesh/tetmesh/surface.rs
@@ -48,6 +48,7 @@ pub struct TetFace {
     pub tet_index: usize,
     /// Index of the face within the tet betweeen 0 and 4.
     pub face_index: usize,
+    pub cell_type: CellType,
 }
 
 impl TetFace {
@@ -120,6 +121,7 @@ impl<T: Real> TetMesh<T> {
                     tri: tri_at(cell, tet_face),
                     tet_index: i,
                     face_index: face_idx,
+                    cell_type: CellType::Tetrahedron,
                 };
 
                 let key = SortedTri::new(face.tri);

--- a/src/mesh/tetmesh/surface.rs
+++ b/src/mesh/tetmesh/surface.rs
@@ -3,6 +3,7 @@ use crate::index::{CheckedIndex, Index};
 use crate::mesh::topology::*;
 use crate::mesh::*;
 use crate::Real;
+use std::fmt;
 
 use super::TetMesh;
 
@@ -49,6 +50,15 @@ pub struct TetFace {
     /// Index of the face within the tet betweeen 0 and 4.
     pub face_index: usize,
     pub cell_type: CellType,
+}
+impl fmt::Debug for TetFace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "TetFace {{ tri: {:?}, tet_index: {}, face_index: {}, cell_type: {:?} }}",
+            self.tri, self.tet_index, self.face_index, self.cell_type
+        )
+    }
 }
 
 impl TetFace {

--- a/src/mesh/tetmesh/surface.rs
+++ b/src/mesh/tetmesh/surface.rs
@@ -16,7 +16,7 @@ pub struct SortedTri {
 }
 
 impl SortedTri {
-    fn new([a, b, c]: [usize; 3]) -> Self {
+    pub(crate) fn new([a, b, c]: [usize; 3]) -> Self {
         SortedTri {
             sorted_indices: {
                 if a <= b {
@@ -63,7 +63,7 @@ impl TetFace {
 
 /// A utility function to index a slice using three indices, creating a new array of 3
 /// corresponding entries of the slice.
-fn tri_at<T: Copy>(slice: &[T], tri: &[usize; 3]) -> [T; 3] {
+pub fn tri_at<T: Copy>(slice: &[T], tri: &[usize; 3]) -> [T; 3] {
     [slice[tri[0]], slice[tri[1]], slice[tri[2]]]
 }
 

--- a/src/mesh/tetmesh/surface.rs
+++ b/src/mesh/tetmesh/surface.rs
@@ -11,7 +11,7 @@ use ahash::RandomState;
 
 /// A triangle with sorted vertices
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
-struct SortedTri {
+pub struct SortedTri {
     pub sorted_indices: [usize; 3],
 }
 

--- a/src/mesh/tetmesh/surface.rs
+++ b/src/mesh/tetmesh/surface.rs
@@ -48,7 +48,7 @@ pub struct TetFace {
     /// Index of the corresponding tet within the source tetmesh.
     pub tet_index: usize,
     /// Index of the face within the tet betweeen 0 and 4.
-    pub face_index: usize,
+    pub face_index: u16,
     pub cell_type: CellType,
 }
 impl fmt::Debug for TetFace {
@@ -130,7 +130,7 @@ impl<T: Real> TetMesh<T> {
                 let face = TetFace {
                     tri: tri_at(cell, tet_face),
                     tet_index: i,
-                    face_index: face_idx,
+                    face_index: face_idx as u16,
                     cell_type: CellType::Tetrahedron,
                 };
 
@@ -185,7 +185,7 @@ impl<T: Real> TetMesh<T> {
         for face in triangles.into_iter().map(|(_, face)| face).filter(filter) {
             surface_topo.push(face.tri);
             tet_indices.push(face.tet_index);
-            tet_face_indices.push(face.face_index);
+            tet_face_indices.push(face.face_index as usize);
         }
 
         (surface_topo, tet_indices, tet_face_indices)

--- a/src/mesh/unstructured_mesh.rs
+++ b/src/mesh/unstructured_mesh.rs
@@ -66,6 +66,45 @@ impl CellType {
             CellType::HexagonalPrism => {}*/
         }
     }
+    pub fn num_tri_faces(&self) -> usize {
+        match self {
+            CellType::Triangle => 1,
+            CellType::Quad => 0,
+            CellType::Tetrahedron => 4,
+            CellType::Pyramid => 4,
+            CellType::Hexahedron => 0,
+            CellType::Wedge => 2,
+        }
+    }
+    pub fn num_quad_faces(&self) -> usize {
+        match self {
+            CellType::Triangle => 0,
+            CellType::Quad => 1,
+            CellType::Tetrahedron => 0,
+            CellType::Pyramid => 1,
+            CellType::Hexahedron => 6,
+            CellType::Wedge => 3,
+        }
+    }
+
+    // see https://raw.githubusercontent.com/Kitware/vtk-examples/gh-pages/src/Testing/Baseline/Cxx/GeometricObjects/TestLinearCellDemo.png
+    // for vertex positions.
+    pub const TETRAHEDRON_FACES: [[usize; 3]; 4] = [[1, 3, 2], [0, 2, 3], [0, 3, 1], [0, 1, 2]];
+
+    pub const PYRAMID_TRIS: [[usize; 3]; 4] = [[0, 4, 1], [1, 4, 2], [2, 4, 3], [3, 4, 0]];
+    pub const PYRAMID_QUAD: [usize; 4] = [0, 1, 2, 3];
+
+    pub const WEDGE_TRIS: [[usize; 3]; 2] = [[0, 2, 1], [3, 4, 5]];
+    pub const WEDGE_QUADS: [[usize; 4]; 3] = [[0, 3, 5, 2], [2, 5, 4, 1], [1, 4, 3, 0]];
+
+    pub const HEXAHEDRON_FACES: [[usize; 4]; 6] = [
+        [0, 1, 2, 3],
+        [0, 3, 7, 4],
+        [0, 4, 5, 1],
+        [6, 2, 1, 5],
+        [6, 5, 4, 7],
+        [6, 7, 3, 2],
+    ];
 }
 
 /// Mesh with arbitrarily shaped elements or cells.

--- a/src/mesh/unstructured_mesh.rs
+++ b/src/mesh/unstructured_mesh.rs
@@ -5,6 +5,8 @@
 //! cells of arbitrary shape.
 //!
 
+mod surface;
+
 use crate::attrib::*;
 use crate::mesh::topology::*;
 use crate::mesh::vertex_positions::VertexPositions;
@@ -16,8 +18,26 @@ use flatk::*;
 /// A marker for the type of cell contained in a Mesh.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum CellType {
-    Tetrahedron,
     Triangle,
+    Quad,
+    Tetrahedron,
+    Pyramid,
+    Hexahedron,
+    Wedge,
+    /*VtkEmptyCell,
+    Vertex,
+    Line,
+    PolyLine,
+    VtkTriangleStrip,
+    VtkPolygon,
+    VtkPixel,
+    VtkQuad,
+    Voxel,
+    Hexahedron,
+    Wedge,
+    Pyramid,
+    PentagonalPrism,
+    HexagonalPrism,*/
 }
 
 impl CellType {
@@ -25,7 +45,25 @@ impl CellType {
     pub fn num_verts(&self) -> usize {
         match self {
             CellType::Triangle => 3,
+            CellType::Quad => 4,
             CellType::Tetrahedron => 4,
+            CellType::Pyramid => 5,
+            CellType::Hexahedron => 8,
+            CellType::Wedge => 6,
+            /*CellType::VtkEmptyCell => 0,
+            CellType::Vertex => 1,
+            CellType::Line => 2,
+            CellType::PolyLine =>
+            CellType::VtkTriangleStrip => {}
+            CellType::VtkPolygon => {}
+            CellType::VtkPixel => {}
+            CellType::VtkQuad => {}
+            CellType::Voxel => {}
+            CellType::Hexahedron => {}
+            CellType::Wedge => {}
+            CellType::Pyramid => {}
+            CellType::PentagonalPrism => {}
+            CellType::HexagonalPrism => {}*/
         }
     }
 }

--- a/src/mesh/unstructured_mesh.rs
+++ b/src/mesh/unstructured_mesh.rs
@@ -24,20 +24,6 @@ pub enum CellType {
     Pyramid,
     Hexahedron,
     Wedge,
-    /*VtkEmptyCell,
-    Vertex,
-    Line,
-    PolyLine,
-    VtkTriangleStrip,
-    VtkPolygon,
-    VtkPixel,
-    VtkQuad,
-    Voxel,
-    Hexahedron,
-    Wedge,
-    Pyramid,
-    PentagonalPrism,
-    HexagonalPrism,*/
 }
 
 impl CellType {
@@ -50,20 +36,6 @@ impl CellType {
             CellType::Pyramid => 5,
             CellType::Hexahedron => 8,
             CellType::Wedge => 6,
-            /*CellType::VtkEmptyCell => 0,
-            CellType::Vertex => 1,
-            CellType::Line => 2,
-            CellType::PolyLine =>
-            CellType::VtkTriangleStrip => {}
-            CellType::VtkPolygon => {}
-            CellType::VtkPixel => {}
-            CellType::VtkQuad => {}
-            CellType::Voxel => {}
-            CellType::Hexahedron => {}
-            CellType::Wedge => {}
-            CellType::Pyramid => {}
-            CellType::PentagonalPrism => {}
-            CellType::HexagonalPrism => {}*/
         }
     }
     pub fn num_tri_faces(&self) -> usize {
@@ -748,7 +720,7 @@ impl<T: Real> Mesh<T> {
 
         let quantize = |x: T| num_traits::Float::round(x / epsilon).to_i32().unwrap();
 
-        for (old_index, position) in self.vertex_positions.iter().enumerate() {
+        for position in self.vertex_positions.iter() {
             let quantized = [
                 quantize(position[0].clone()),
                 quantize(position[1].clone()),

--- a/src/mesh/unstructured_mesh.rs
+++ b/src/mesh/unstructured_mesh.rs
@@ -16,7 +16,7 @@ use crate::Real;
 use flatk::*;
 
 /// A marker for the type of cell contained in a Mesh.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CellType {
     Triangle,
     Quad,

--- a/src/mesh/unstructured_mesh/surface.rs
+++ b/src/mesh/unstructured_mesh/surface.rs
@@ -1,0 +1,325 @@
+use crate::{CellType, Index, Mesh, Real, SortedTri, TetFace, TriMesh};
+
+use crate::attrib::{Attrib, AttribDict, IntrinsicAttribute};
+use crate::topology::{
+    CellIndex, CellVertex, CellVertexIndex, FaceIndex, FaceVertexIndex, NumVertices, VertexIndex,
+};
+use ahash::AHashMap as HashMap;
+use ahash::RandomState;
+
+/// A quad with sorted vertices
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
+struct SortedQuad {
+    pub sorted_indices: [usize; 4],
+}
+
+impl SortedQuad {
+    fn new(indices: [usize; 4]) -> Self {
+        let mut indices = indices.clone();
+        indices.sort();
+        SortedQuad {
+            sorted_indices: indices,
+        }
+    }
+}
+
+/// A triangle face of a tetrahedron within a `TetMesh`.
+#[derive(Copy, Clone, Eq)]
+pub struct QuadFace {
+    /// Vertex indices in the source mesh forming this face.
+    pub quad: [usize; 4],
+    /// Index of the corresponding quad within the source mesh.
+    pub quad_index: usize,
+    /// Index of the face within the tet betweeen 0 and 4.
+    pub face_index: usize,
+}
+
+impl QuadFace {
+    #[rustfmt::skip]
+    const PERMUTATIONS: [[usize; 4]; 24] = [
+        [1, 2, 3, 4], [2, 1, 3, 4], [3, 1, 2, 4], [1, 3, 2, 4],
+        [2, 3, 1, 4], [3, 2, 1, 4], [3, 2, 4, 1], [2, 3, 4, 1],
+        [4, 3, 2, 1], [3, 4, 2, 1], [2, 4, 3, 1], [4, 2, 3, 1],
+        [4, 1, 3, 2], [1, 4, 3, 2], [3, 4, 1, 2], [4, 3, 1, 2],
+        [1, 3, 4, 2], [3, 1, 4, 2], [2, 1, 4, 3], [1, 2, 4, 3],
+        [4, 2, 1, 3], [2, 4, 1, 3], [1, 4, 2, 3], [4, 1, 2, 3],
+    ];
+}
+
+/// A utility function to index a slice using four indices, creating a new array of 4
+/// corresponding entries of the slice.
+fn quad_at<T: Copy>(slice: &[T], quad: &[usize; 4]) -> [T; 4] {
+    [
+        slice[quad[0]],
+        slice[quad[1]],
+        slice[quad[2]],
+        slice[quad[3]],
+    ]
+}
+
+/// Consider any permutation of the triangle to be equivalent to the original.
+impl PartialEq for QuadFace {
+    fn eq(&self, other: &QuadFace) -> bool {
+        for p in Self::PERMUTATIONS.iter() {
+            if quad_at(&other.quad, p) == self.quad {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+impl PartialOrd for QuadFace {
+    fn partial_cmp(&self, other: &QuadFace) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Lexicographic ordering of the sorted indices.
+impl Ord for QuadFace {
+    fn cmp(&self, other: &QuadFace) -> std::cmp::Ordering {
+        let mut quad = self.quad;
+        quad.sort_unstable();
+        let mut other_quad = other.quad;
+        other_quad.sort_unstable();
+        quad.cmp(&other_quad)
+    }
+}
+
+impl<T: Real> Mesh<T> {
+    /// A helper function to compute surface topology of a generic mesh specified by the given cells.
+    ///
+    /// The algorithm is to iterate over every face and upon seeing a duplicate, remove it from
+    /// the list. this will leave only unique faces, which correspond to the surface of the
+    /// `Mesh`.
+    ///
+    /// This function assumes that the given Mesh is a manifold.
+    fn surface_ngon_set<'a>(
+        cells: impl std::iter::ExactSizeIterator<Item = &'a [usize]>,
+    ) -> (HashMap<SortedTri, TetFace>, HashMap<SortedQuad, QuadFace>) {
+        let mut triangles: HashMap<SortedTri, TetFace> = {
+            // This will make surfacing tetmeshes deterministic.
+            let hash_builder = RandomState::with_seeds(7, 47, 2377, 719);
+            HashMap::with_capacity_and_hasher(cells.len() * 4, hash_builder)
+        };
+        let mut quads: HashMap<SortedQuad, QuadFace> = {
+            // This will make surfacing tetmeshes deterministic.
+            let hash_builder = RandomState::with_seeds(7, 47, 2377, 719);
+            HashMap::with_capacity_and_hasher(cells.len() * 4, hash_builder)
+        };
+        // todo: figure out how to accept the list of cells divided by type
+        //  ensure below algo actualyl works
+        //  and and seperate by cell type how we process teh cells.
+        //  might need cell enums to have explicit definition>??>
+        let add_quad_faces = |(i, cell): (usize, &[usize; 4])| {
+            for (face_idx, quad_face) in Self::TET_FACES.iter().enumerate() {
+                let face = QuadFace {
+                    quad: quad_at(cell, quad_face),
+                    quad_index: i,
+                    face_index: face_idx,
+                };
+
+                let key = SortedQuad::new(face.quad);
+
+                if quads.remove(&key).is_none() {
+                    quads.insert(key, face);
+                }
+            }
+        };
+
+        cells.enumerate().for_each(add_quad_faces);
+        (triangles, quads)
+    }
+
+    /// Extract the surface ngon information of the `Mesh`.
+    ///
+    /// Only record those faces that are accepted by `filter`.
+    ///
+    /// This includes the ngon topology, which cell each ngon came from and which face on
+    /// the originating cell it belongs to.  The returned vectors have the same size.
+    ///
+    /// This function assumes that the given mesh is a manifold.
+    ///
+    /// (triangles, quads, cells, cell_face_indices)
+    pub fn surface_ngon_data<F>(
+        &self,
+        filter: F,
+    ) -> (Vec<[usize; 3]>, Vec<[usize; 4]>, Vec<usize>, Vec<usize>)
+    where
+        F: FnMut(&TetFace) -> bool,
+    {
+        let (triangles, quads) = Self::surface_ngon_set(self.cell_iter(), self.cell_type_iter());
+
+        let total = triangles.len() + quads.len();
+        let mut surface_tris = Vec::with_capacity(triangles.len());
+        let mut surface_quads = Vec::with_capacity(quads.len());
+        let mut cell_indices = Vec::with_capacity(total);
+        let mut cell_face_indices = Vec::with_capacity(total);
+        for face in triangles.into_iter().map(|(_, face)| face).filter(filter) {
+            surface_tris.push(face.quad);
+            cell_indices.push(face.quad_index);
+            cell_face_indices.push(face.face_index);
+        }
+        for face in quads.into_iter().map(|(_, face)| face).filter(filter) {
+            surface_quads.push(face.quad);
+            cell_indices.push(face.quad_index);
+            cell_face_indices.push(face.face_index);
+        }
+
+        (surface_topo, cell_indices, cell_face_indices)
+    }
+
+    pub fn surface_mesh(&self) -> Mesh<T> {
+        self.surface_trimesh_with_mapping_and_filter(None, None, None, None, |_| true)
+    }
+
+    pub fn surface_trimesh_with_mapping(
+        &self,
+        original_vertex_index_name: Option<&str>,
+        original_tet_index_name: Option<&str>,
+        original_tet_vertex_index_name: Option<&str>,
+        original_tet_face_index_name: Option<&str>,
+    ) -> Mesh<T> {
+        self.surface_trimesh_with_mapping_and_filter(
+            original_vertex_index_name,
+            original_tet_index_name,
+            original_tet_vertex_index_name,
+            original_tet_face_index_name,
+            |_| true,
+        )
+    }
+
+    pub fn surface_trimesh_with_mapping_and_filter(
+        &self,
+        original_vertex_index_name: Option<&str>,
+        original_tet_index_name: Option<&str>,
+        original_tet_vertex_index_name: Option<&str>,
+        original_tet_face_index_name: Option<&str>,
+        filter: impl FnMut(&TetFace) -> bool,
+    ) -> Mesh<T> {
+        // Get the surface topology of this tetmesh.
+        let (mut tri_topo, mut quad_topo, cell_indices, cell_face_indices) =
+            self.surface_ngon_data(filter);
+
+        // Record which vertices we have already handled.
+        let mut seen = vec![-1isize; self.num_vertices()];
+
+        // Record the mapping back to tet vertices.
+        let mut original_vertex_index = Vec::with_capacity(tri_topo.len());
+
+        // Accumulate surface vertex positions for the new trimesh.
+        let mut surf_vert_pos = Vec::with_capacity(tri_topo.len());
+
+        for face in tri_topo.iter_mut() {
+            for idx in face.iter_mut() {
+                if seen[*idx] == -1 {
+                    surf_vert_pos.push(self.vertex_positions[*idx]);
+                    original_vertex_index.push(*idx);
+                    seen[*idx] = (surf_vert_pos.len() - 1) as isize;
+                }
+                *idx = seen[*idx] as usize;
+            }
+        }
+
+        surf_vert_pos.shrink_to_fit();
+        original_vertex_index.shrink_to_fit();
+
+        let num_surf_verts = surf_vert_pos.len();
+
+        // Transfer vertex attributes.
+        let mut vertex_attributes: AttribDict<VertexIndex> = AttribDict::new();
+
+        for (name, attrib) in self.attrib_dict::<VertexIndex>().iter() {
+            let new_attrib = attrib.duplicate_with_len(num_surf_verts, |mut new, old| {
+                for (&idx, val) in seen.iter().zip(old.iter()) {
+                    if idx != -1 {
+                        new.get_mut(idx as usize).clone_from_other(val).unwrap();
+                    }
+                }
+            });
+            vertex_attributes.insert(name.to_string(), new_attrib);
+        }
+
+        // Transfer triangle attributes from tetrahedron attributes.
+        let mut face_attributes: AttribDict<FaceIndex> = AttribDict::new();
+
+        for (name, attrib) in self.attrib_dict::<CellIndex>().iter() {
+            face_attributes.insert(
+                name.to_string(),
+                attrib.promote_with(|new, old| {
+                    for &tet_idx in cell_indices.iter() {
+                        new.push_cloned(old.get(tet_idx));
+                    }
+                }),
+            );
+        }
+
+        // Mapping from face vertex index to its original tet vertex index.
+        /*let mut tet_vertex_index = Vec::new();
+        if original_tet_vertex_index_name.is_some() {
+            tet_vertex_index.reserve(topo.len() * 3);
+            for (&tet_idx, &tet_face_idx) in cell_indices.iter().zip(cell_face_indices.iter()) {
+                let tri = &Self::TET_FACES[tet_face_idx];
+                for &i in tri.iter() {
+                    tet_vertex_index.push(self.cell_vertex(tet_idx, i));
+                }
+            }
+        }*/
+
+        // Transfer face vertex attributes from tetmesh.
+        let mut face_vertex_attributes: AttribDict<FaceVertexIndex> = AttribDict::new();
+
+        for (name, attrib) in self.attrib_dict::<CellVertexIndex>().iter() {
+            face_vertex_attributes.insert(
+                name.to_string(),
+                attrib.promote_with(|new, old| {
+                    for (&tet_idx, &tet_face_idx) in
+                        cell_indices.iter().zip(cell_face_indices.iter())
+                    {
+                        for &i in Self::TET_FACES[tet_face_idx].iter() {
+                            let tet_vtx_idx = self.cell_vertex(tet_idx, i);
+                            new.push_cloned(old.get(Index::from(tet_vtx_idx).unwrap()));
+                        }
+                    }
+                }),
+            );
+        }
+
+        let mut trimesh = TriMesh {
+            vertex_positions: IntrinsicAttribute::from_vec(surf_vert_pos),
+            indices: IntrinsicAttribute::from_vec(tri_topo),
+            vertex_attributes,
+            face_attributes,
+            face_vertex_attributes,
+            face_edge_attributes: AttribDict::new(), // TetMeshes don't have edge attributes (yet)
+            attribute_value_cache: self.attribute_value_cache.clone(),
+        };
+
+        // Add the mapping to the original tetmesh. Overwrite any existing attributes.
+        /*if let Some(name) = original_vertex_index_name {
+            trimesh
+                .set_attrib_data::<_, VertexIndex>(name, original_vertex_index)
+                .expect("Failed to add original vertex index attribute.");
+        }
+
+        if let Some(name) = original_tet_index_name {
+            trimesh
+                .set_attrib_data::<_, FaceIndex>(name, cell_indices)
+                .expect("Failed to add original tet index attribute.");
+        }
+
+        if let Some(name) = original_tet_vertex_index_name {
+            trimesh
+                .set_attrib_data::<_, FaceVertexIndex>(name, tet_vertex_index)
+                .expect("Failed to add original tet vertex index attribute.");
+        }
+
+        if let Some(name) = original_tet_face_index_name {
+            trimesh
+                .set_attrib_data::<_, FaceIndex>(name, cell_face_indices)
+                .expect("Failed to add original tet face index attribute.");
+        }*/
+
+        trimesh
+    }
+}

--- a/src/mesh/unstructured_mesh/surface.rs
+++ b/src/mesh/unstructured_mesh/surface.rs
@@ -111,23 +111,14 @@ impl<T: Real> Mesh<T> {
         indices: &flatk::Clumped<Vec<usize>>,
         types: impl std::iter::ExactSizeIterator<Item = &'a CellType> + Clone,
     ) -> (HashMap<SortedTri, TetFace>, HashMap<SortedQuad, QuadFace>) {
-        let mut tri_count = 0;
-        let mut quad_count = 0;
-
-        for (cells, cell_type) in indices.clump_iter().zip(types.clone()) {
-            let cell_count = cells.view().data.len() * cells.view().chunk_size;
-            tri_count += cell_type.num_tri_faces() * cell_count;
-            quad_count += cell_type.num_quad_faces() * cell_count;
-        }
-
         let mut triangles: HashMap<SortedTri, TetFace> = {
             // This will make surfacing tetmeshes deterministic.
             let hash_builder = RandomState::with_seeds(7, 47, 2377, 719);
-            HashMap::with_capacity_and_hasher(tri_count * 3, hash_builder)
+            HashMap::with_hasher(hash_builder)
         };
         let mut quads: HashMap<SortedQuad, QuadFace> = {
             let hash_builder = RandomState::with_seeds(7, 47, 2377, 719);
-            HashMap::with_capacity_and_hasher(quad_count * 4, hash_builder)
+            HashMap::with_hasher(hash_builder)
         };
 
         for (cells, cell_type) in indices.clump_iter().zip(types) {

--- a/src/mesh/unstructured_mesh/surface.rs
+++ b/src/mesh/unstructured_mesh/surface.rs
@@ -1,4 +1,4 @@
-use crate::{tri_at, CellType, Index, Mesh, PolyMesh, Real, SortedTri, TetFace, TriMesh};
+use crate::{tri_at, CellType, Index, Mesh, PolyMesh, Real, SortedTri, TetFace};
 use std::fmt;
 
 use crate::attrib::{Attrib, AttribDict, IntrinsicAttribute};
@@ -8,7 +8,6 @@ use crate::topology::{
 };
 use ahash::AHashMap as HashMap;
 use ahash::RandomState;
-use flatk::ChunkedN;
 
 /// A quad with sorted vertices
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
@@ -34,7 +33,7 @@ pub struct QuadFace {
     /// Index of the corresponding quad within the source mesh.
     pub cell_index: usize,
     /// Index of the face within the cell
-    pub face_index: usize,
+    pub face_index: u16,
     pub cell_type: CellType,
 }
 
@@ -138,7 +137,7 @@ impl<T: Real> Mesh<T> {
                         let face = TetFace {
                             tri: tri_at(cell, tri_face),
                             tet_index: i,
-                            face_index,
+                            face_index: face_index as u16,
                             cell_type: *cell_type,
                         };
 
@@ -154,7 +153,7 @@ impl<T: Real> Mesh<T> {
                         let face = QuadFace {
                             quad: quad_at(cell, quad_face),
                             cell_index: i,
-                            face_index,
+                            face_index: face_index as u16,
                             cell_type: *cell_type,
                         };
 
@@ -215,7 +214,7 @@ impl<T: Real> Mesh<T> {
             vertices.extend_from_slice(&face.tri);
             offsets.push(vertices.len());
             cell_indices.push(face.tet_index);
-            cell_face_indices.push(face.face_index);
+            cell_face_indices.push(face.face_index.into());
             cell_types.push(face.cell_type);
         }
 
@@ -223,7 +222,7 @@ impl<T: Real> Mesh<T> {
             vertices.extend_from_slice(&face.quad);
             offsets.push(vertices.len());
             cell_indices.push(face.cell_index);
-            cell_face_indices.push(face.face_index);
+            cell_face_indices.push(face.face_index as usize);
             cell_types.push(face.cell_type);
         }
 
@@ -401,7 +400,6 @@ impl<T: Real> Mesh<T> {
 }
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::mesh::{CellType, Mesh};
 
     #[test]

--- a/src/mesh/unstructured_mesh/surface.rs
+++ b/src/mesh/unstructured_mesh/surface.rs
@@ -267,7 +267,7 @@ impl<T: Real> Mesh<T> {
         quad_filter: impl FnMut(&QuadFace) -> bool,
     ) -> PolyMesh<T> {
         // Get the surface topology of this tetmesh.
-        let (mut topo, offsets, cell_indices, cell_face_indices, cell_types) =
+        let (mut topo, mut offsets, cell_indices, cell_face_indices, cell_types) =
             self.surface_ngon_data(tri_filter, quad_filter);
 
         // Record which vertices we have already handled.
@@ -359,6 +359,7 @@ impl<T: Real> Mesh<T> {
             );
         }
 
+        offsets.push(topo.len());
         let mut polymesh = PolyMesh {
             vertex_positions: IntrinsicAttribute::from_vec(surf_vert_pos),
             indices: topo,


### PR DESCRIPTION
Adds Pyramid, Hexahedron, Wedge, and Quad cell types to the Mesh<T> (unstructured grid type) as well as `Mesh<T>::surface_mesh() -> PolyMesh<T>`
Also adds utility functions for enumerating cell faces.